### PR TITLE
Fixed Duplicate Endpoints Bug

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -71,6 +71,9 @@ def get_matched_endpoint(api_spec: ReducedOpenAPISpec, plan: str):
         # return ['GET /api/v2/team/9008245063/space']
         # raise ValueError(f"Endpoint {plan_endpoint} not found in API spec.")
     
+    #Remove duplicates (fixes issue with Found x matching duplicate endpoints)
+    matched_endpoints = list(set(matched_endpoints))
+
     print("UTILS: MATCHED ENDPOINTS 57:")
     print(matched_endpoints)
     print("\n\n")


### PR DESCRIPTION
Sometimes the API Selector detects duplicate matched endpoints as more than 1. 

![multiple_endpoints_bug](https://github.com/Agile-Loop/Synapse-Copilot/assets/15957528/049b569d-5555-4cec-b029-078aa45b6cbc)
